### PR TITLE
Fix connection options for MongoDB

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -64,7 +64,11 @@ db.create = function (options) {
 function Db(options) {
   this.options = options;
   this.connectionString = this.options.connectionString;
-  this.connectionOptions = this.options.connectionOptions || null;
+  // MongoClient expects an options object; passing `null` causes a
+  // TypeError in recent MongoDB drivers. Default to an empty object
+  // so the driver can apply its own defaults when no options are
+  // provided.
+  this.connectionOptions = this.options.connectionOptions || {};
   if (!this.connectionString && this.options.host) {
     this.connectionString = url.format({
       protocol: "mongodb",


### PR DESCRIPTION
## Summary
- ensure an object is passed to MongoClient

## Testing
- `npm test` *(fails: assert-plus cannot read env variables)*

------
https://chatgpt.com/codex/tasks/task_e_685139f89ef083328aa1293abfe59c4b