### PR TITLE
Add Db.close with tests

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -122,6 +122,27 @@ Db.prototype.createStore = function (namespace) {
 };
 
 /**
+ * Close the underlying MongoDB connection if one exists.
+ *
+ * @param {Function} [fn] optional callback
+ * @return {Promise} resolves when the client is closed
+ */
+Db.prototype.close = function (fn) {
+  var promise;
+  if (this.Client && typeof this.Client.close === 'function') {
+    promise = this.Client.close();
+    this.Client = null;
+    this.Db = null;
+  } else {
+    promise = Promise.resolve();
+  }
+  if (fn) {
+    promise.then(function () { fn(); }).catch(fn);
+  }
+  return promise;
+};
+
+/**
  * Initialize a space in the database (eg. a collection).
  *
  * @param {String} namespace

--- a/test/db-remote.unit.js
+++ b/test/db-remote.unit.js
@@ -18,11 +18,15 @@ before(function(done){
 });
 
 after(function(done){
-  if (client) {
-    client.close().then(function(){ done(); }).catch(done);
-  } else {
-    done();
+  function finish(err){
+    if (err) return done(err);
+    if (client) {
+      client.close().then(function(){ done(); }).catch(done);
+    } else {
+      done();
+    }
   }
+  tester.close().then(function(){ finish(); }).catch(finish);
 });
 
 beforeEach(function(done){

--- a/test/db.unit.js
+++ b/test/db.unit.js
@@ -222,4 +222,18 @@ describe('store', function(){
       });
     });
   });
+
+  describe('.close()', function(){
+    it('should close the connection without errors', function(done){
+      tester.close().then(function(){
+        expect(tester.Client).to.not.exist;
+        expect(tester.Db).to.not.exist;
+        done();
+      }).catch(done);
+    });
+  });
+});
+
+after(function(done){
+  tester.close().then(function(){ done(); }).catch(done);
 });


### PR DESCRIPTION
## Summary
- implement `Db.prototype.close` to close Mongo client
- test cleanup to invoke `close`
- add unit test verifying close behavior

## Testing
- `./node_modules/.bin/mocha --reporter spec --timeout 5000 --exit` *(fails: "before all" hook)*

------
https://chatgpt.com/codex/tasks/task_e_68513ed9eb788332b2d54bc5632d6b52